### PR TITLE
Convert to OAuth and PRAW4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *~
 *.swp
 
-# the legit config
-equalconf.yaml
+# the legit configs
+praw.ini
+sublist.yaml

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ The equalbot is a simple reddit bot for setting a per user submission count limi
 Requirements
 ------------
 
- * [PRAW](https://praw.readthedocs.org/)
+ * [PRAW4](https://praw.readthedocs.io/en/praw4/index.html)
  * [PyYAML](http://pyyaml.org/)
 
 Setup
 -----
 
-Copy the example configuration to a file called `equalconf.yaml` (which is expected to be in the same directory as the bot), and edit at least the stuff in caps to suit your needs. Then create a wiki page at `/r/YOURSUBREDDIT/wiki/equalbot` and define subreddit-specific settings as YAML, just like for AutoModerator.
+Copy the example configurations to a files called `praw.ini` and `sublist.yaml` (which are expected to be in the same directory as the bot), and edit at least the stuff in caps to suit your needs. Note that the `client_id` and `client_secret` values are obtained in your [account preferences](https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example#first-steps). Then create a wiki page at `/r/YOURSUBREDDIT/wiki/equalbot` and define subreddit-specific settings as YAML, just like for AutoModerator.
 
     count: 5 # number of posts allowed per...
     hours: 20 # this time period
@@ -21,8 +21,6 @@ Copy the example configuration to a file called `equalconf.yaml` (which is expec
 If `comment` is excluded, the equalbot will operate silently.
 
 It is recommended that editing of the wiki page be very restricted. Note that the account used must be a moderator with post and wiki privileges in the sub(s) given.
-
-The equalbot optionally supports PRAW's [praw-multiprocess](http://praw.readthedocs.org/en/latest/pages/multiprocess.html) program. Set `multiprocess` to `true` in the configuration to enable this functionality.
 
 Usage
 -----

--- a/equalbot.py
+++ b/equalbot.py
@@ -36,10 +36,10 @@ def sortposts(posts):
             counts[post.author.name] = [post.id]
     return counts
 
-def remoteconf(sub):
+def remoteconf(r, sub):
     """Return parsed remote config for a subreddit."""
     try:
-        page = r.get_wiki_page(sub, "equalbot")
+        page = r.subreddit(sub).wiki['equalbot']
         rconf = yaml.safe_load(page.content_md)
     except:
         print(sub + ": trouble parsing wiki page")
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
     # check and change our list of subreddits
     for sub in conf["subs"]:
-        rconf = remoteconf(sub)
+        rconf = remoteconf(r, sub)
         if not rconf:
             continue
         rsub = r.get_subreddit(sub)

--- a/equalbot.py
+++ b/equalbot.py
@@ -60,20 +60,14 @@ def warn(posts, r, conf):
         comment.distinguish()
 
 if __name__ == "__main__":
-    # load configuration options from file beside ourself
+    # load subreddit list from file beside ourself
     mypath = os.path.dirname(os.path.realpath(__file__))
-    myconf = open(mypath + "/equalconf.yaml", "r")
+    myconf = open(mypath + "/sublist.yaml", "r")
     conf = yaml.safe_load(myconf)
     myconf.close()
 
     # connect to reddit
-    if conf["multiprocess"]:
-        myhandler = praw.handlers.MultiprocessHandler()
-    else:
-        myhandler = None
-    r = praw.Reddit(user_agent=conf["useragent"], handler=myhandler)
-    r.config.decode_html_entities = True
-    r.login(username=conf["username"], password=conf["password"])
+    r = praw.Reddit()
 
     # check and change our list of subreddits
     for sub in conf["subs"]:

--- a/equalbot.py
+++ b/equalbot.py
@@ -5,7 +5,7 @@ import praw
 import time
 import yaml
 
-def countposts(posts, conf):
+def countposts(conf, posts):
     """Return submissions over our limit."""
     naughty = []
     for user in posts:
@@ -13,12 +13,12 @@ def countposts(posts, conf):
             naughty.append(posts[user].pop(0))
     return naughty
 
-def getposts(rsub, conf):
+def getposts(r, sub, conf):
     """Fetch all submissions posted within our timeframe."""
     myposts = []
     mynow = int(time.time())
     seconds = conf["hours"] * 60 * 60
-    allposts = rsub.get_new(limit = 0)
+    allposts = r.subreddit(sub).new()
     for post in allposts:
         if (mynow - post.created_utc) > seconds:
             break
@@ -31,9 +31,9 @@ def sortposts(posts):
     counts = {}
     for post in posts:
         if post.author.name in counts.keys():
-            counts[post.author.name].append(post.id)
+            counts[post.author.name].append(post)
         else:
-            counts[post.author.name] = [post.id]
+            counts[post.author.name] = [post]
     return counts
 
 def remoteconf(r, sub):
@@ -47,17 +47,16 @@ def remoteconf(r, sub):
     if "count" in rconf and "hours" in rconf:
         return rconf
 
-def remove(posts, r):
+def remove(r, posts):
     """Remove list of submissions."""
     for post in posts:
-        r.get_submission(submission_id = post).remove()
+        r.subreddit(str(post.subreddit)).mod.remove(post)
 
-def warn(posts, r, conf):
+def warn(r, conf, posts):
     """Post comments explaining why we removed the submission."""
     for post in posts:
-        mypost = r.get_submission(submission_id = post)
-        comment = mypost.add_comment(conf["comment"])
-        comment.distinguish()
+        comment = post.reply(conf["comment"])
+        r.subreddit(str(post.subreddit)).mod.distinguish(comment)
 
 if __name__ == "__main__":
     # load subreddit list from file beside ourself
@@ -74,10 +73,9 @@ if __name__ == "__main__":
         rconf = remoteconf(r, sub)
         if not rconf:
             continue
-        rsub = r.get_subreddit(sub)
-        submissions = getposts(rsub, rconf)
+        submissions = getposts(r, sub, rconf)
         userposts = sortposts(submissions)
-        violations = countposts(userposts, rconf)
-        remove(violations, r)
+        violations = countposts(rconf, userposts)
+        remove(r, violations)
         if "comment" in rconf:
-            warn(violations, r, rconf)
+            warn(r, rconf, violations)

--- a/equalconf.yaml.example
+++ b/equalconf.yaml.example
@@ -1,9 +1,0 @@
-%YAML 1.1
----
-username: "YOURMODACCT"
-password: "TOPSECRET"
-# https://github.com/reddit/reddit/wiki/API#rules
-useragent: "Equalbot_v0.2 by (/u/YOURUSERNAME)"
-multiprocess: false
-subs:
-  - "YOURSUBREDDIT"

--- a/praw.ini.example
+++ b/praw.ini.example
@@ -1,0 +1,7 @@
+[DEFAULT]
+# https://github.com/reddit/reddit/wiki/API#rules
+user_agent: python:com.scymrian-meritocracy.post-rate-limiter:v0.3.0 (by /u/YOURUSERNAME)
+client_id: ALONGCODE
+client_secret: ANEVENLONGERCODE
+username: YOURMODACCT
+password: TOPSECRET

--- a/sublist.yaml.example
+++ b/sublist.yaml.example
@@ -1,0 +1,4 @@
+%YAML 1.1
+---
+subs:
+  - "YOURSUBREDDIT"


### PR DESCRIPTION
Does what it says on the tin. Logic is unchanged, except for the praw-multiprocess support being removed. PRAW4 watches the HTTP headers to handle it instead. What configuration could be moved into a standard `praw.ini` file was.
